### PR TITLE
Handle firebase auth failures to not break gatsby build

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,4 @@
+const report = require('gatsby-cli/lib/reporter');
 const firebase = require('firebase-admin');
 const crypto = require('crypto');
 
@@ -11,7 +12,15 @@ exports.sourceNodes = async (
   { boundActionCreators },
   { types, credential }
 ) => {
-  firebase.initializeApp({ credential: firebase.credential.cert(credential) });
+
+  try{
+    firebase.initializeApp({ credential: firebase.credential.cert(credential) });
+  } catch (e) {
+    report.warn('Could not initialize Firebase. Please check `credential` property in gatsby-config.js');
+    report.warn(e);
+    return;
+  }
+
   const db = firebase.firestore();
 
   const { createNode, createNodeField } = boundActionCreators;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "author": "Yao Bin Then <alvinthen890703@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "firebase-admin": "^5.8.1"
+    "firebase-admin": "^5.8.1",
+    "gatsby-cli": "^1.1.58"
   },
   "files": [
     "gatsby-node.js",


### PR DESCRIPTION
Added this to allow gatsby build without requiring access to a firesource project
https://github.com/taessina/gatsby-source-firestore/issues/5