### PR TITLE
Fixed the firestore timestamp warning

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,7 +13,7 @@ exports.sourceNodes = async (
   { types, credential }
 ) => {
 
-  try{
+  try {
     firebase.initializeApp({ credential: firebase.credential.cert(credential) });
   } catch (e) {
     report.warn('Could not initialize Firebase. Please check `credential` property in gatsby-config.js');
@@ -22,6 +22,15 @@ exports.sourceNodes = async (
   }
 
   const db = firebase.firestore();
+
+  try {
+    // To hide the Firestore timestamp warning
+    const settings = { timestampsInSnapshots: true };
+    db.settings(settings);
+  } catch (e) {
+    console.log(`ERROR on update the db settings`)
+    console.error(e)
+  }
 
   const { createNode, createNodeField } = boundActionCreators;
 


### PR DESCRIPTION
When I was using this plugin I noticed the warning below and added a little snippet to fix it.

```
The behavior for Date objects stored in Firestore is going to change
AND YOUR APP MAY BREAK.
To hide this warning and ensure your app does not break, you need to add the
following code to your app before calling any other Cloud Firestore methods:

  const firestore = new Firestore();
  const settings = {/* your settings... */ timestampsInSnapshots: true};
  firestore.settings(settings);

With this change, timestamps stored in Cloud Firestore will be read back as
Firebase Timestamp objects instead of as system Date objects. So you will also
need to update code expecting a Date to instead expect a Timestamp. For example:

  // Old:
  const date = snapshot.get('created_at');
  // New:
  const timestamp = snapshot.get('created_at');
  const date = timestamp.toDate();

Please audit all existing usages of Date when you enable the new behavior. In a
future release, the behavior will change to the new behavior, so if you do not
follow these steps, YOUR APP MAY BREAK.
```