### PR TITLE
init with appConfig instead of credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,18 @@ as a data source
         {
           resolve: `gatsby-source-firestore`,
           options: {
+            // credential or appConfig
             credential: require(`./credentials.json`),
+            appConfig: {
+              apiKey: "api-key",
+              authDomain: "project-id.firebaseapp.com",
+              databaseURL: "https://project-id.firebaseio.com",
+              projectId: "project-id",
+              storageBucket: "project-id.appspot.com",
+              messagingSenderId: "sender-id",
+              appID: "app-id",
+
+            },
             types: [
               {
                 type: `Book`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,13 +10,12 @@ const getDigest = id =>
 
 exports.sourceNodes = async (
   { boundActionCreators },
-  { types, credential }
+  { types, credential, appConfig }
 ) => {
   try {
     if (firebase.apps || !firebase.apps.length) {
-      firebase.initializeApp({
-        credential: firebase.credential.cert(credential),
-      });
+      const cfg = appConfig ? appConfig : {credential: firebase.credential.cert(credential)}
+      firebase.initializeApp(cfg);
     }
   } catch (e) {
     report.warn(


### PR DESCRIPTION
Hi,
In order to build gatsby in a CI where we can't commit the credentials.json file in the repo, we need to init Firebase with a config different than "credential".
Could you please merge this PR?
Thanks